### PR TITLE
feat(endpoints): Add query_range endpoint and fix response in OpenAPISpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ pip install python-loki-client
 This client is still incomplete and implements only the following endpoints:
 
 - `GET /loki/api/v1/query`
+- `GET /loki/api/v1/query_range`
 
 ## Usage
 
 First, create a client:
 
 ```python
-from loki_client import Client
+from grafana_loki_client import Client
 
 client = Client(base_url="https://loki.grafana.com")
 ```
@@ -33,9 +34,9 @@ client = Client(base_url="https://loki.grafana.com")
 Now call your endpoint and use your models:
 
 ```python
-from loki_client.models import MyDataModel
-from loki_client.api.my_tag import get_my_data_model
-from loki_client.types import Response
+from grafana_loki_client.models import MyDataModel
+from grafana_loki_client.api.my_tag import get_my_data_model
+from grafana_loki_client.types import Response
 
 my_data: MyDataModel = get_my_data_model.sync(client=client)
 # or if you need more info (e.g. status_code)
@@ -45,9 +46,9 @@ response: Response[MyDataModel] = get_my_data_model.sync_detailed(client=client)
 Or do the same thing with an async version:
 
 ```python
-from loki_client.models import MyDataModel
-from loki_client.api.my_tag import get_my_data_model
-from loki_client.types import Response
+from grafana_loki_client.models import MyDataModel
+from grafana_loki_client.api.my_tag import get_my_data_model
+from grafana_loki_client.types import Response
 
 my_data: MyDataModel = await get_my_data_model.asyncio(client=client)
 response: Response[MyDataModel] = await get_my_data_model.asyncio_detailed(client=client)

--- a/grafana_loki_client/api/query/get_loki_api_v1_query.py
+++ b/grafana_loki_client/api/query/get_loki_api_v1_query.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional, Union
 import httpx
 
 from ...client import Client
-from ...models.get_loki_api_v1_query_direction import GetLokiApiV1QueryDirection
+from ...models.direction import Direction
 from ...models.query_response_body import QueryResponseBody
 from ...types import UNSET, Response, Unset
 
@@ -15,7 +15,7 @@ def _get_kwargs(
     query: str,
     limit: int = 100,
     time: Union[Unset, None, datetime.datetime] = UNSET,
-    direction: GetLokiApiV1QueryDirection = GetLokiApiV1QueryDirection.BACKWARD,
+    direction: Direction = Direction.BACKWARD,
     x_scope_org_id: Union[Unset, str] = UNSET,
 ) -> Dict[str, Any]:
     url = f"{client.base_url}/loki/api/v1/query"
@@ -76,7 +76,7 @@ def sync_detailed(
     query: str,
     limit: int = 100,
     time: Union[Unset, None, datetime.datetime] = UNSET,
-    direction: GetLokiApiV1QueryDirection = GetLokiApiV1QueryDirection.BACKWARD,
+    direction: Direction = Direction.BACKWARD,
     x_scope_org_id: Union[Unset, str] = UNSET,
 ) -> Response[QueryResponseBody]:
     """
@@ -84,7 +84,7 @@ def sync_detailed(
         query (str):
         limit (int):  Default: 100.
         time (Union[Unset, None, datetime.datetime]):
-        direction (GetLokiApiV1QueryDirection):  Default: GetLokiApiV1QueryDirection.BACKWARD.
+        direction (Direction):  Default: Direction.BACKWARD.
         x_scope_org_id (Union[Unset, str]):
 
     Returns:
@@ -114,7 +114,7 @@ def sync(
     query: str,
     limit: int = 100,
     time: Union[Unset, None, datetime.datetime] = UNSET,
-    direction: GetLokiApiV1QueryDirection = GetLokiApiV1QueryDirection.BACKWARD,
+    direction: Direction = Direction.BACKWARD,
     x_scope_org_id: Union[Unset, str] = UNSET,
 ) -> Optional[QueryResponseBody]:
     """
@@ -122,7 +122,7 @@ def sync(
         query (str):
         limit (int):  Default: 100.
         time (Union[Unset, None, datetime.datetime]):
-        direction (GetLokiApiV1QueryDirection):  Default: GetLokiApiV1QueryDirection.BACKWARD.
+        direction (Direction):  Default: Direction.BACKWARD.
         x_scope_org_id (Union[Unset, str]):
 
     Returns:
@@ -145,7 +145,7 @@ async def asyncio_detailed(
     query: str,
     limit: int = 100,
     time: Union[Unset, None, datetime.datetime] = UNSET,
-    direction: GetLokiApiV1QueryDirection = GetLokiApiV1QueryDirection.BACKWARD,
+    direction: Direction = Direction.BACKWARD,
     x_scope_org_id: Union[Unset, str] = UNSET,
 ) -> Response[QueryResponseBody]:
     """
@@ -153,7 +153,7 @@ async def asyncio_detailed(
         query (str):
         limit (int):  Default: 100.
         time (Union[Unset, None, datetime.datetime]):
-        direction (GetLokiApiV1QueryDirection):  Default: GetLokiApiV1QueryDirection.BACKWARD.
+        direction (Direction):  Default: Direction.BACKWARD.
         x_scope_org_id (Union[Unset, str]):
 
     Returns:
@@ -181,7 +181,7 @@ async def asyncio(
     query: str,
     limit: int = 100,
     time: Union[Unset, None, datetime.datetime] = UNSET,
-    direction: GetLokiApiV1QueryDirection = GetLokiApiV1QueryDirection.BACKWARD,
+    direction: Direction = Direction.BACKWARD,
     x_scope_org_id: Union[Unset, str] = UNSET,
 ) -> Optional[QueryResponseBody]:
     """
@@ -189,7 +189,7 @@ async def asyncio(
         query (str):
         limit (int):  Default: 100.
         time (Union[Unset, None, datetime.datetime]):
-        direction (GetLokiApiV1QueryDirection):  Default: GetLokiApiV1QueryDirection.BACKWARD.
+        direction (Direction):  Default: Direction.BACKWARD.
         x_scope_org_id (Union[Unset, str]):
 
     Returns:

--- a/grafana_loki_client/api/query_range/get_loki_api_v1_query_range.py
+++ b/grafana_loki_client/api/query_range/get_loki_api_v1_query_range.py
@@ -3,9 +3,7 @@ from typing import Any, Dict, Optional, Union
 import httpx
 
 from ...client import Client
-from ...models.get_loki_api_v1_query_range_direction import (
-    GetLokiApiV1QueryRangeDirection,
-)
+from ...models.direction import Direction
 from ...models.query_response_body import QueryResponseBody
 from ...types import UNSET, Response, Unset
 
@@ -15,13 +13,11 @@ def _get_kwargs(
     client: Client,
     query: str,
     limit: Union[Unset, None, int] = 100,
-    start: Union[Unset, None, int] = UNSET,
-    end: Union[Unset, None, int] = UNSET,
-    step: Union[Unset, None, str] = UNSET,
+    start: Union[None, Unset, float, int, str] = UNSET,
+    end: Union[None, Unset, float, int, str] = UNSET,
+    step: Union[None, Unset, float, int, str] = UNSET,
     interval: Union[Unset, None, float] = UNSET,
-    direction: Union[
-        Unset, None, GetLokiApiV1QueryRangeDirection
-    ] = GetLokiApiV1QueryRangeDirection.BACKWARD,
+    direction: Union[Unset, None, Direction] = Direction.BACKWARD,
     x_scope_org_id: Union[Unset, str] = UNSET,
 ) -> Dict[str, Any]:
     url = f"{client.base_url}/loki/api/v1/query_range"
@@ -37,11 +33,38 @@ def _get_kwargs(
 
     params["limit"] = limit
 
-    params["start"] = start
+    json_start: Union[None, Unset, float, int, str]
+    if isinstance(start, Unset):
+        json_start = UNSET
+    elif start is None:
+        json_start = None
 
-    params["end"] = end
+    else:
+        json_start = start
 
-    params["step"] = step
+    params["start"] = json_start
+
+    json_end: Union[None, Unset, float, int, str]
+    if isinstance(end, Unset):
+        json_end = UNSET
+    elif end is None:
+        json_end = None
+
+    else:
+        json_end = end
+
+    params["end"] = json_end
+
+    json_step: Union[None, Unset, float, int, str]
+    if isinstance(step, Unset):
+        json_step = UNSET
+    elif step is None:
+        json_step = None
+
+    else:
+        json_step = step
+
+    params["step"] = json_step
 
     params["interval"] = interval
 
@@ -85,25 +108,22 @@ def sync_detailed(
     client: Client,
     query: str,
     limit: Union[Unset, None, int] = 100,
-    start: Union[Unset, None, int] = UNSET,
-    end: Union[Unset, None, int] = UNSET,
-    step: Union[Unset, None, str] = UNSET,
+    start: Union[None, Unset, float, int, str] = UNSET,
+    end: Union[None, Unset, float, int, str] = UNSET,
+    step: Union[None, Unset, float, int, str] = UNSET,
     interval: Union[Unset, None, float] = UNSET,
-    direction: Union[
-        Unset, None, GetLokiApiV1QueryRangeDirection
-    ] = GetLokiApiV1QueryRangeDirection.BACKWARD,
+    direction: Union[Unset, None, Direction] = Direction.BACKWARD,
     x_scope_org_id: Union[Unset, str] = UNSET,
 ) -> Response[QueryResponseBody]:
     """
     Args:
         query (str):
         limit (Union[Unset, None, int]):  Default: 100.
-        start (Union[Unset, None, int]):
-        end (Union[Unset, None, int]):
-        step (Union[Unset, None, str]):
+        start (Union[None, Unset, float, int, str]):
+        end (Union[None, Unset, float, int, str]):
+        step (Union[None, Unset, float, int, str]):
         interval (Union[Unset, None, float]):
-        direction (Union[Unset, None, GetLokiApiV1QueryRangeDirection]):  Default:
-            GetLokiApiV1QueryRangeDirection.BACKWARD.
+        direction (Union[Unset, None, Direction]):  Default: Direction.BACKWARD.
         x_scope_org_id (Union[Unset, str]):
 
     Returns:
@@ -135,25 +155,22 @@ def sync(
     client: Client,
     query: str,
     limit: Union[Unset, None, int] = 100,
-    start: Union[Unset, None, int] = UNSET,
-    end: Union[Unset, None, int] = UNSET,
-    step: Union[Unset, None, str] = UNSET,
+    start: Union[None, Unset, float, int, str] = UNSET,
+    end: Union[None, Unset, float, int, str] = UNSET,
+    step: Union[None, Unset, float, int, str] = UNSET,
     interval: Union[Unset, None, float] = UNSET,
-    direction: Union[
-        Unset, None, GetLokiApiV1QueryRangeDirection
-    ] = GetLokiApiV1QueryRangeDirection.BACKWARD,
+    direction: Union[Unset, None, Direction] = Direction.BACKWARD,
     x_scope_org_id: Union[Unset, str] = UNSET,
 ) -> Optional[QueryResponseBody]:
     """
     Args:
         query (str):
         limit (Union[Unset, None, int]):  Default: 100.
-        start (Union[Unset, None, int]):
-        end (Union[Unset, None, int]):
-        step (Union[Unset, None, str]):
+        start (Union[None, Unset, float, int, str]):
+        end (Union[None, Unset, float, int, str]):
+        step (Union[None, Unset, float, int, str]):
         interval (Union[Unset, None, float]):
-        direction (Union[Unset, None, GetLokiApiV1QueryRangeDirection]):  Default:
-            GetLokiApiV1QueryRangeDirection.BACKWARD.
+        direction (Union[Unset, None, Direction]):  Default: Direction.BACKWARD.
         x_scope_org_id (Union[Unset, str]):
 
     Returns:
@@ -178,25 +195,22 @@ async def asyncio_detailed(
     client: Client,
     query: str,
     limit: Union[Unset, None, int] = 100,
-    start: Union[Unset, None, int] = UNSET,
-    end: Union[Unset, None, int] = UNSET,
-    step: Union[Unset, None, str] = UNSET,
+    start: Union[None, Unset, float, int, str] = UNSET,
+    end: Union[None, Unset, float, int, str] = UNSET,
+    step: Union[None, Unset, float, int, str] = UNSET,
     interval: Union[Unset, None, float] = UNSET,
-    direction: Union[
-        Unset, None, GetLokiApiV1QueryRangeDirection
-    ] = GetLokiApiV1QueryRangeDirection.BACKWARD,
+    direction: Union[Unset, None, Direction] = Direction.BACKWARD,
     x_scope_org_id: Union[Unset, str] = UNSET,
 ) -> Response[QueryResponseBody]:
     """
     Args:
         query (str):
         limit (Union[Unset, None, int]):  Default: 100.
-        start (Union[Unset, None, int]):
-        end (Union[Unset, None, int]):
-        step (Union[Unset, None, str]):
+        start (Union[None, Unset, float, int, str]):
+        end (Union[None, Unset, float, int, str]):
+        step (Union[None, Unset, float, int, str]):
         interval (Union[Unset, None, float]):
-        direction (Union[Unset, None, GetLokiApiV1QueryRangeDirection]):  Default:
-            GetLokiApiV1QueryRangeDirection.BACKWARD.
+        direction (Union[Unset, None, Direction]):  Default: Direction.BACKWARD.
         x_scope_org_id (Union[Unset, str]):
 
     Returns:
@@ -226,25 +240,22 @@ async def asyncio(
     client: Client,
     query: str,
     limit: Union[Unset, None, int] = 100,
-    start: Union[Unset, None, int] = UNSET,
-    end: Union[Unset, None, int] = UNSET,
-    step: Union[Unset, None, str] = UNSET,
+    start: Union[None, Unset, float, int, str] = UNSET,
+    end: Union[None, Unset, float, int, str] = UNSET,
+    step: Union[None, Unset, float, int, str] = UNSET,
     interval: Union[Unset, None, float] = UNSET,
-    direction: Union[
-        Unset, None, GetLokiApiV1QueryRangeDirection
-    ] = GetLokiApiV1QueryRangeDirection.BACKWARD,
+    direction: Union[Unset, None, Direction] = Direction.BACKWARD,
     x_scope_org_id: Union[Unset, str] = UNSET,
 ) -> Optional[QueryResponseBody]:
     """
     Args:
         query (str):
         limit (Union[Unset, None, int]):  Default: 100.
-        start (Union[Unset, None, int]):
-        end (Union[Unset, None, int]):
-        step (Union[Unset, None, str]):
+        start (Union[None, Unset, float, int, str]):
+        end (Union[None, Unset, float, int, str]):
+        step (Union[None, Unset, float, int, str]):
         interval (Union[Unset, None, float]):
-        direction (Union[Unset, None, GetLokiApiV1QueryRangeDirection]):  Default:
-            GetLokiApiV1QueryRangeDirection.BACKWARD.
+        direction (Union[Unset, None, Direction]):  Default: Direction.BACKWARD.
         x_scope_org_id (Union[Unset, str]):
 
     Returns:

--- a/grafana_loki_client/api/query_range/get_loki_api_v1_query_range.py
+++ b/grafana_loki_client/api/query_range/get_loki_api_v1_query_range.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Any, Dict, Optional, Union
 
 import httpx
@@ -13,9 +14,9 @@ def _get_kwargs(
     client: Client,
     query: str,
     limit: Union[Unset, None, int] = 100,
-    start: Union[None, Unset, float, int, str] = UNSET,
-    end: Union[None, Unset, float, int, str] = UNSET,
-    step: Union[None, Unset, float, int, str] = UNSET,
+    start: Union[None, Unset, datetime.datetime, float, int] = UNSET,
+    end: Union[None, Unset, datetime.datetime, float, int] = UNSET,
+    step: Union[None, Unset, datetime.datetime, float, int] = UNSET,
     interval: Union[Unset, None, float] = UNSET,
     direction: Union[Unset, None, Direction] = Direction.BACKWARD,
     x_scope_org_id: Union[Unset, str] = UNSET,
@@ -39,6 +40,9 @@ def _get_kwargs(
     elif start is None:
         json_start = None
 
+    elif isinstance(start, datetime.datetime):
+        json_start = start.isoformat()
+
     else:
         json_start = start
 
@@ -50,6 +54,9 @@ def _get_kwargs(
     elif end is None:
         json_end = None
 
+    elif isinstance(end, datetime.datetime):
+        json_end = end.isoformat()
+
     else:
         json_end = end
 
@@ -60,6 +67,9 @@ def _get_kwargs(
         json_step = UNSET
     elif step is None:
         json_step = None
+
+    elif isinstance(step, datetime.datetime):
+        json_step = step.isoformat()
 
     else:
         json_step = step
@@ -108,9 +118,9 @@ def sync_detailed(
     client: Client,
     query: str,
     limit: Union[Unset, None, int] = 100,
-    start: Union[None, Unset, float, int, str] = UNSET,
-    end: Union[None, Unset, float, int, str] = UNSET,
-    step: Union[None, Unset, float, int, str] = UNSET,
+    start: Union[None, Unset, datetime.datetime, float, int] = UNSET,
+    end: Union[None, Unset, datetime.datetime, float, int] = UNSET,
+    step: Union[None, Unset, datetime.datetime, float, int] = UNSET,
     interval: Union[Unset, None, float] = UNSET,
     direction: Union[Unset, None, Direction] = Direction.BACKWARD,
     x_scope_org_id: Union[Unset, str] = UNSET,
@@ -119,9 +129,9 @@ def sync_detailed(
     Args:
         query (str):
         limit (Union[Unset, None, int]):  Default: 100.
-        start (Union[None, Unset, float, int, str]):
-        end (Union[None, Unset, float, int, str]):
-        step (Union[None, Unset, float, int, str]):
+        start (Union[None, Unset, datetime.datetime, float, int]):
+        end (Union[None, Unset, datetime.datetime, float, int]):
+        step (Union[None, Unset, datetime.datetime, float, int]):
         interval (Union[Unset, None, float]):
         direction (Union[Unset, None, Direction]):  Default: Direction.BACKWARD.
         x_scope_org_id (Union[Unset, str]):
@@ -155,9 +165,9 @@ def sync(
     client: Client,
     query: str,
     limit: Union[Unset, None, int] = 100,
-    start: Union[None, Unset, float, int, str] = UNSET,
-    end: Union[None, Unset, float, int, str] = UNSET,
-    step: Union[None, Unset, float, int, str] = UNSET,
+    start: Union[None, Unset, datetime.datetime, float, int] = UNSET,
+    end: Union[None, Unset, datetime.datetime, float, int] = UNSET,
+    step: Union[None, Unset, datetime.datetime, float, int] = UNSET,
     interval: Union[Unset, None, float] = UNSET,
     direction: Union[Unset, None, Direction] = Direction.BACKWARD,
     x_scope_org_id: Union[Unset, str] = UNSET,
@@ -166,9 +176,9 @@ def sync(
     Args:
         query (str):
         limit (Union[Unset, None, int]):  Default: 100.
-        start (Union[None, Unset, float, int, str]):
-        end (Union[None, Unset, float, int, str]):
-        step (Union[None, Unset, float, int, str]):
+        start (Union[None, Unset, datetime.datetime, float, int]):
+        end (Union[None, Unset, datetime.datetime, float, int]):
+        step (Union[None, Unset, datetime.datetime, float, int]):
         interval (Union[Unset, None, float]):
         direction (Union[Unset, None, Direction]):  Default: Direction.BACKWARD.
         x_scope_org_id (Union[Unset, str]):
@@ -195,9 +205,9 @@ async def asyncio_detailed(
     client: Client,
     query: str,
     limit: Union[Unset, None, int] = 100,
-    start: Union[None, Unset, float, int, str] = UNSET,
-    end: Union[None, Unset, float, int, str] = UNSET,
-    step: Union[None, Unset, float, int, str] = UNSET,
+    start: Union[None, Unset, datetime.datetime, float, int] = UNSET,
+    end: Union[None, Unset, datetime.datetime, float, int] = UNSET,
+    step: Union[None, Unset, datetime.datetime, float, int] = UNSET,
     interval: Union[Unset, None, float] = UNSET,
     direction: Union[Unset, None, Direction] = Direction.BACKWARD,
     x_scope_org_id: Union[Unset, str] = UNSET,
@@ -206,9 +216,9 @@ async def asyncio_detailed(
     Args:
         query (str):
         limit (Union[Unset, None, int]):  Default: 100.
-        start (Union[None, Unset, float, int, str]):
-        end (Union[None, Unset, float, int, str]):
-        step (Union[None, Unset, float, int, str]):
+        start (Union[None, Unset, datetime.datetime, float, int]):
+        end (Union[None, Unset, datetime.datetime, float, int]):
+        step (Union[None, Unset, datetime.datetime, float, int]):
         interval (Union[Unset, None, float]):
         direction (Union[Unset, None, Direction]):  Default: Direction.BACKWARD.
         x_scope_org_id (Union[Unset, str]):
@@ -240,9 +250,9 @@ async def asyncio(
     client: Client,
     query: str,
     limit: Union[Unset, None, int] = 100,
-    start: Union[None, Unset, float, int, str] = UNSET,
-    end: Union[None, Unset, float, int, str] = UNSET,
-    step: Union[None, Unset, float, int, str] = UNSET,
+    start: Union[None, Unset, datetime.datetime, float, int] = UNSET,
+    end: Union[None, Unset, datetime.datetime, float, int] = UNSET,
+    step: Union[None, Unset, datetime.datetime, float, int] = UNSET,
     interval: Union[Unset, None, float] = UNSET,
     direction: Union[Unset, None, Direction] = Direction.BACKWARD,
     x_scope_org_id: Union[Unset, str] = UNSET,
@@ -251,9 +261,9 @@ async def asyncio(
     Args:
         query (str):
         limit (Union[Unset, None, int]):  Default: 100.
-        start (Union[None, Unset, float, int, str]):
-        end (Union[None, Unset, float, int, str]):
-        step (Union[None, Unset, float, int, str]):
+        start (Union[None, Unset, datetime.datetime, float, int]):
+        end (Union[None, Unset, datetime.datetime, float, int]):
+        step (Union[None, Unset, datetime.datetime, float, int]):
         interval (Union[Unset, None, float]):
         direction (Union[Unset, None, Direction]):  Default: Direction.BACKWARD.
         x_scope_org_id (Union[Unset, str]):

--- a/grafana_loki_client/api/query_range/get_loki_api_v1_query_range.py
+++ b/grafana_loki_client/api/query_range/get_loki_api_v1_query_range.py
@@ -1,0 +1,266 @@
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ...client import Client
+from ...models.get_loki_api_v1_query_range_direction import (
+    GetLokiApiV1QueryRangeDirection,
+)
+from ...models.query_response_body import QueryResponseBody
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+    query: str,
+    limit: Union[Unset, None, int] = 100,
+    start: Union[Unset, None, int] = UNSET,
+    end: Union[Unset, None, int] = UNSET,
+    step: Union[Unset, None, str] = UNSET,
+    interval: Union[Unset, None, float] = UNSET,
+    direction: Union[
+        Unset, None, GetLokiApiV1QueryRangeDirection
+    ] = GetLokiApiV1QueryRangeDirection.BACKWARD,
+    x_scope_org_id: Union[Unset, str] = UNSET,
+) -> Dict[str, Any]:
+    url = f"{client.base_url}/loki/api/v1/query_range"
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    if not isinstance(x_scope_org_id, Unset):
+        headers["X-Scope-OrgID"] = x_scope_org_id
+
+    params: Dict[str, Any] = {}
+    params["query"] = query
+
+    params["limit"] = limit
+
+    params["start"] = start
+
+    params["end"] = end
+
+    params["step"] = step
+
+    params["interval"] = interval
+
+    json_direction: Union[Unset, None, str] = UNSET
+    if not isinstance(direction, Unset):
+        json_direction = direction.value if direction else None
+
+    params["direction"] = json_direction
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    return {
+        "method": "get",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "params": params,
+    }
+
+
+def _parse_response(*, response: httpx.Response) -> Optional[QueryResponseBody]:
+    if response.status_code == 200:
+        response_200 = QueryResponseBody.from_dict(response.json())
+
+        return response_200
+    return None
+
+
+def _build_response(*, response: httpx.Response) -> Response[QueryResponseBody]:
+    return Response(
+        status_code=response.status_code,
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+    query: str,
+    limit: Union[Unset, None, int] = 100,
+    start: Union[Unset, None, int] = UNSET,
+    end: Union[Unset, None, int] = UNSET,
+    step: Union[Unset, None, str] = UNSET,
+    interval: Union[Unset, None, float] = UNSET,
+    direction: Union[
+        Unset, None, GetLokiApiV1QueryRangeDirection
+    ] = GetLokiApiV1QueryRangeDirection.BACKWARD,
+    x_scope_org_id: Union[Unset, str] = UNSET,
+) -> Response[QueryResponseBody]:
+    """
+    Args:
+        query (str):
+        limit (Union[Unset, None, int]):  Default: 100.
+        start (Union[Unset, None, int]):
+        end (Union[Unset, None, int]):
+        step (Union[Unset, None, str]):
+        interval (Union[Unset, None, float]):
+        direction (Union[Unset, None, GetLokiApiV1QueryRangeDirection]):  Default:
+            GetLokiApiV1QueryRangeDirection.BACKWARD.
+        x_scope_org_id (Union[Unset, str]):
+
+    Returns:
+        Response[QueryResponseBody]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        query=query,
+        limit=limit,
+        start=start,
+        end=end,
+        step=step,
+        interval=interval,
+        direction=direction,
+        x_scope_org_id=x_scope_org_id,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(response=response)
+
+
+def sync(
+    *,
+    client: Client,
+    query: str,
+    limit: Union[Unset, None, int] = 100,
+    start: Union[Unset, None, int] = UNSET,
+    end: Union[Unset, None, int] = UNSET,
+    step: Union[Unset, None, str] = UNSET,
+    interval: Union[Unset, None, float] = UNSET,
+    direction: Union[
+        Unset, None, GetLokiApiV1QueryRangeDirection
+    ] = GetLokiApiV1QueryRangeDirection.BACKWARD,
+    x_scope_org_id: Union[Unset, str] = UNSET,
+) -> Optional[QueryResponseBody]:
+    """
+    Args:
+        query (str):
+        limit (Union[Unset, None, int]):  Default: 100.
+        start (Union[Unset, None, int]):
+        end (Union[Unset, None, int]):
+        step (Union[Unset, None, str]):
+        interval (Union[Unset, None, float]):
+        direction (Union[Unset, None, GetLokiApiV1QueryRangeDirection]):  Default:
+            GetLokiApiV1QueryRangeDirection.BACKWARD.
+        x_scope_org_id (Union[Unset, str]):
+
+    Returns:
+        Response[QueryResponseBody]
+    """
+
+    return sync_detailed(
+        client=client,
+        query=query,
+        limit=limit,
+        start=start,
+        end=end,
+        step=step,
+        interval=interval,
+        direction=direction,
+        x_scope_org_id=x_scope_org_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+    query: str,
+    limit: Union[Unset, None, int] = 100,
+    start: Union[Unset, None, int] = UNSET,
+    end: Union[Unset, None, int] = UNSET,
+    step: Union[Unset, None, str] = UNSET,
+    interval: Union[Unset, None, float] = UNSET,
+    direction: Union[
+        Unset, None, GetLokiApiV1QueryRangeDirection
+    ] = GetLokiApiV1QueryRangeDirection.BACKWARD,
+    x_scope_org_id: Union[Unset, str] = UNSET,
+) -> Response[QueryResponseBody]:
+    """
+    Args:
+        query (str):
+        limit (Union[Unset, None, int]):  Default: 100.
+        start (Union[Unset, None, int]):
+        end (Union[Unset, None, int]):
+        step (Union[Unset, None, str]):
+        interval (Union[Unset, None, float]):
+        direction (Union[Unset, None, GetLokiApiV1QueryRangeDirection]):  Default:
+            GetLokiApiV1QueryRangeDirection.BACKWARD.
+        x_scope_org_id (Union[Unset, str]):
+
+    Returns:
+        Response[QueryResponseBody]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        query=query,
+        limit=limit,
+        start=start,
+        end=end,
+        step=step,
+        interval=interval,
+        direction=direction,
+        x_scope_org_id=x_scope_org_id,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+    query: str,
+    limit: Union[Unset, None, int] = 100,
+    start: Union[Unset, None, int] = UNSET,
+    end: Union[Unset, None, int] = UNSET,
+    step: Union[Unset, None, str] = UNSET,
+    interval: Union[Unset, None, float] = UNSET,
+    direction: Union[
+        Unset, None, GetLokiApiV1QueryRangeDirection
+    ] = GetLokiApiV1QueryRangeDirection.BACKWARD,
+    x_scope_org_id: Union[Unset, str] = UNSET,
+) -> Optional[QueryResponseBody]:
+    """
+    Args:
+        query (str):
+        limit (Union[Unset, None, int]):  Default: 100.
+        start (Union[Unset, None, int]):
+        end (Union[Unset, None, int]):
+        step (Union[Unset, None, str]):
+        interval (Union[Unset, None, float]):
+        direction (Union[Unset, None, GetLokiApiV1QueryRangeDirection]):  Default:
+            GetLokiApiV1QueryRangeDirection.BACKWARD.
+        x_scope_org_id (Union[Unset, str]):
+
+    Returns:
+        Response[QueryResponseBody]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            query=query,
+            limit=limit,
+            start=start,
+            end=end,
+            step=step,
+            interval=interval,
+            direction=direction,
+            x_scope_org_id=x_scope_org_id,
+        )
+    ).parsed

--- a/grafana_loki_client/models/__init__.py
+++ b/grafana_loki_client/models/__init__.py
@@ -1,7 +1,6 @@
 """ Contains all the data models used in inputs/outputs """
 
-from .get_loki_api_v1_query_direction import GetLokiApiV1QueryDirection
-from .get_loki_api_v1_query_range_direction import GetLokiApiV1QueryRangeDirection
+from .direction import Direction
 from .query_response_body import QueryResponseBody
 from .query_response_data import QueryResponseData
 from .query_response_data_result_type import QueryResponseDataResultType

--- a/grafana_loki_client/models/__init__.py
+++ b/grafana_loki_client/models/__init__.py
@@ -1,6 +1,7 @@
 """ Contains all the data models used in inputs/outputs """
 
 from .get_loki_api_v1_query_direction import GetLokiApiV1QueryDirection
+from .get_loki_api_v1_query_range_direction import GetLokiApiV1QueryRangeDirection
 from .query_response_body import QueryResponseBody
 from .query_response_data import QueryResponseData
 from .query_response_data_result_type import QueryResponseDataResultType

--- a/grafana_loki_client/models/direction.py
+++ b/grafana_loki_client/models/direction.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class Direction(str, Enum):
+    FORWARD = "forward"
+    BACKWARD = "backward"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/grafana_loki_client/models/get_loki_api_v1_query_direction.py
+++ b/grafana_loki_client/models/get_loki_api_v1_query_direction.py
@@ -1,9 +1,0 @@
-from enum import Enum
-
-
-class GetLokiApiV1QueryDirection(str, Enum):
-    FORWARD = "forward"
-    BACKWARD = "backward"
-
-    def __str__(self) -> str:
-        return str(self.value)

--- a/grafana_loki_client/models/get_loki_api_v1_query_range_direction.py
+++ b/grafana_loki_client/models/get_loki_api_v1_query_range_direction.py
@@ -1,9 +1,0 @@
-from enum import Enum
-
-
-class GetLokiApiV1QueryRangeDirection(str, Enum):
-    FORWARD = "forward"
-    BACKWARD = "backward"
-
-    def __str__(self) -> str:
-        return str(self.value)

--- a/grafana_loki_client/models/get_loki_api_v1_query_range_direction.py
+++ b/grafana_loki_client/models/get_loki_api_v1_query_range_direction.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class GetLokiApiV1QueryRangeDirection(str, Enum):
+    FORWARD = "forward"
+    BACKWARD = "backward"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/grafana_loki_client/models/query_response_result.py
+++ b/grafana_loki_client/models/query_response_result.py
@@ -13,18 +13,18 @@ T = TypeVar("T", bound="QueryResponseResult")
 class QueryResponseResult:
     """
     Attributes:
-        value (List[str]):
+        values (List[str]):
         metric (Union[Unset, QueryResponseMetric]):
         streams (Union[Unset, QueryResponseStreams]):
     """
 
-    value: List[str]
+    values: List[str]
     metric: Union[Unset, QueryResponseMetric] = UNSET
     streams: Union[Unset, QueryResponseStreams] = UNSET
     additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
-        value = self.value
+        values = self.values
 
         metric: Union[Unset, Dict[str, Any]] = UNSET
         if not isinstance(self.metric, Unset):
@@ -38,7 +38,7 @@ class QueryResponseResult:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "value": value,
+                "values": values,
             }
         )
         if metric is not UNSET:
@@ -51,7 +51,7 @@ class QueryResponseResult:
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
-        value = cast(List[str], d.pop("value"))
+        values = cast(List[str], d.pop("values"))
 
         _metric = d.pop("metric", UNSET)
         metric: Union[Unset, QueryResponseMetric]
@@ -68,7 +68,7 @@ class QueryResponseResult:
             streams = QueryResponseStreams.from_dict(_streams)
 
         query_response_result = cls(
-            value=value,
+            values=values,
             metric=metric,
             streams=streams,
         )

--- a/grafana_loki_openapi.yaml
+++ b/grafana_loki_openapi.yaml
@@ -31,10 +31,7 @@ paths:
           in: query
           required: true
           schema:
-            enum:
-              - "forward"
-              - "backward"
-            default: "backward"
+            $ref: "#/components/schemas/Direction"
         - name: X-Scope-OrgID
           in: header
           schema:
@@ -65,15 +62,15 @@ paths:
         - name: start
           in: query
           schema:
-            type: integer
+            $ref: "#/components/schemas/TimestampFormat"
         - name: end
           in: query
           schema:
-            type: integer
+            $ref: "#/components/schemas/TimestampFormat"
         - name: step
           in: query
           schema:
-            type: string
+            $ref: "#/components/schemas/TimestampFormat"
         - name: interval
           in: query
           schema:
@@ -81,10 +78,7 @@ paths:
         - name: direction
           in: query
           schema:
-            enum:
-              - "forward"
-              - "backward"
-            default: "backward"
+            $ref: "#/components/schemas/Direction"
         - name: X-Scope-OrgID
           in: header
           schema:
@@ -98,6 +92,16 @@ paths:
                 $ref: "#/components/schemas/QueryResponseBody"
 components:
   schemas:
+    Direction:
+      enum:
+        - "forward"
+        - "backward"
+      default: "backward"
+    TimestampFormat:
+      oneOf:
+        - type: string
+        - type: integer
+        - type: number
     QueryResponseBody:
       required:
         - status

--- a/grafana_loki_openapi.yaml
+++ b/grafana_loki_openapi.yaml
@@ -100,6 +100,7 @@ components:
     TimestampFormat:
       oneOf:
         - type: string
+          format: date-time
         - type: integer
         - type: number
     QueryResponseBody:

--- a/grafana_loki_openapi.yaml
+++ b/grafana_loki_openapi.yaml
@@ -46,6 +46,56 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/QueryResponseBody"
+  /loki/api/v1/query_range:
+    get:
+      tags:
+        - Query Range
+      parameters:
+        - name: query
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            default: 100
+        - name: start
+          in: query
+          schema:
+            type: integer
+        - name: end
+          in: query
+          schema:
+            type: integer
+        - name: step
+          in: query
+          schema:
+            type: string
+        - name: interval
+          in: query
+          schema:
+            type: number
+        - name: direction
+          in: query
+          schema:
+            enum:
+              - "forward"
+              - "backward"
+            default: "backward"
+        - name: X-Scope-OrgID
+          in: header
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QueryResponseBody"
 components:
   schemas:
     QueryResponseBody:
@@ -82,13 +132,13 @@ components:
     QueryResponseResult:
       type: object
       required:
-        - value
+        - values
       properties:
         metric:
           $ref: "#/components/schemas/QueryResponseMetric"
         streams:
           $ref: "#/components/schemas/QueryResponseStreams"
-        value:
+        values:
           type: array
           items:
             type: string


### PR DESCRIPTION
Test:

```
import json

from grafana_loki_client import Client
from grafana_loki_client.api.query_range import get_loki_api_v1_query_range


query = '{env="production"} |= "my_keyword"'
client = Client("https://loki-internal-host.com")

res = get_loki_api_v1_query_range.sync_detailed(
    client=client, 
    query=query, 
    start=1655051641, 
    end=1657643641, 
    limit=1
)

print(res.status_code)
print(json.dumps(json.loads(res.content), indent=4, default=str))

```